### PR TITLE
add standalone config

### DIFF
--- a/example/flake.nix
+++ b/example/flake.nix
@@ -17,52 +17,52 @@
   };
 
   outputs = inputs@ { nixpkgs, home-manager, plasma-manager, ... }:
-  let
-    # Replace with your username
-    username = "jdoe";
+    let
+      # Replace with your username
+      username = "jdoe";
 
-    # Replace with the fitting architecture
-    system = "x86_64-linux";
-  in
-  {
-    # Replace `standAloneConfig` with the name of your configuration (your `username` or `"username@hostname"`)
-    homeConfigurations.standAloneConfig = home-manager.lib.homeManagerConfiguration {
-      pkgs = import nixpkgs { inherit system; };
+      # Replace with the fitting architecture
+      system = "x86_64-linux";
+    in
+    {
+      # Replace `standAloneConfig` with the name of your configuration (your `username` or `"username@hostname"`)
+      homeConfigurations.standAloneConfig = home-manager.lib.homeManagerConfiguration {
+        pkgs = import nixpkgs { inherit system; };
 
-      modules = [
-        inputs.plasma-manager.homeManagerModules.plasma-manager
-
-        # Specify the path to your home configuration here:
-        ./home.nix
-
-        {
-          home = {
-            inherit username;
-            homeDirectory = "/home/${username}";
-            stateVersion = "23.11";
-          };
-        }
-      ];
-    };
-
-    # Replace `moduleConfig` with the name of you configuration (your `username` or `"username@hostname"`)
-    nixosConfigurations.moduleConfig = nixpkgs.lib.nixosSystem {
-      inherit system;
         modules = [
-        # Here you typically also would have your configuration.nix
+          inputs.plasma-manager.homeManagerModules.plasma-manager
 
-        home-manager.nixosModules.home-manager
+          # Specify the path to your home configuration here:
+          ./home.nix
 
-        {
-          home-manager.useGlobalPkgs = true;
-          home-manager.useUserPackages = true;
-          home-manager.sharedModules = [ plasma-manager.homeManagerModules.plasma-manager ];
+          {
+            home = {
+              inherit username;
+              homeDirectory = "/home/${username}";
+            };
+          }
+        ];
+      };
 
-          # This should point to your home.nix path of course. For an example
-          # of this see ./home.nix in this directory.
-          home-manager.users.jdoe = import ./home.nix;
-        }
-      ];
+      # Replace `moduleConfig` with the name of you configuration (your `username` or `"username@hostname"`)
+      nixosConfigurations.moduleConfig = nixpkgs.lib.nixosSystem {
+        inherit system;
+
+        modules = [
+          # Here you typically also would have your configuration.nix
+
+          home-manager.nixosModules.home-manager
+
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.sharedModules = [ plasma-manager.homeManagerModules.plasma-manager ];
+
+            # This should point to your home.nix path of course. For an example
+            # of this see ./home.nix in this directory.
+            home-manager.users.jdoe = import ./home.nix;
+          }
+        ];
+      };
     };
-  };
 }

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -4,34 +4,65 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
 
-    home-manager.url = "github:nix-community/home-manager/release-23.11";
-    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    home-manager = {
+      url = "github:nix-community/home-manager/release-23.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
-    plasma-manager.url = "github:pjones/plasma-manager";
-    plasma-manager.inputs.nixpkgs.follows = "nixpkgs";
-    plasma-manager.inputs.home-manager.follows = "home-manager";
+    plasma-manager = {
+      url = "github:pjones/plasma-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
+    };
   };
 
-  outputs = inputs@ { nixpkgs, home-manager, plasma-manager, ... }: {
-    nixosConfigurations = {
-      # Replace jdoeSystem with the name of you configuration
-      jdoeSystem = nixpkgs.lib.nixosSystem {
-        # Replace with the fitting architecture
-        system = "x86_64-linux";
-        modules = [
-          # Here you typically also would have your configuration.nix
+  outputs = inputs@ { nixpkgs, home-manager, plasma-manager, ... }:
+  let
+    # Replace with your username
+    username = "jdoe";
 
-          home-manager.nixosModules.home-manager
-          {
-            home-manager.useGlobalPkgs = true;
-            home-manager.useUserPackages = true;
-            home-manager.sharedModules = [ plasma-manager.homeManagerModules.plasma-manager ];
-            # This should point to your home.nix path of course. For an example
-            # of this see ./home.nix in this directory.
-            home-manager.users.jdoe = import ./home.nix;
-          }
-        ];
-      };
+    # Replace with the fitting architecture
+    system = "x86_64-linux";
+  in
+  {
+    # Replace `standAloneConfig` with the name of your configuration (your username or username@hostname)
+    homeConfigurations.standAloneConfig = home-manager.lib.homeManagerConfiguration {
+      pkgs = import nixpkgs { inherit system; };
+
+      modules = [
+        inputs.plasma-manager.homeManagerModules.plasma-manager
+
+        # Specify the path to your home configuration here:
+        ./home.nix
+
+        {
+          home = {
+            inherit username;
+            homeDirectory = "/home/${username}";
+            stateVersion = "23.11";
+          };
+        }
+      ];
+    };
+
+    # Replace `moduleConfig` with the name of you configuration (your username or username@hostname)
+    nixosConfigurations.moduleConfig = nixpkgs.lib.nixosSystem {
+      inherit system;
+        modules = [
+        # Here you typically also would have your configuration.nix
+
+        home-manager.nixosModules.home-manager
+
+        {
+          home-manager.useGlobalPkgs = true;
+          home-manager.useUserPackages = true;
+          home-manager.sharedModules = [ plasma-manager.homeManagerModules.plasma-manager ];
+
+          # This should point to your home.nix path of course. For an example
+          # of this see ./home.nix in this directory.
+          home-manager.users.jdoe = import ./home.nix;
+        }
+      ];
     };
   };
 }

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -25,7 +25,7 @@
     system = "x86_64-linux";
   in
   {
-    # Replace `standAloneConfig` with the name of your configuration (your username or username@hostname)
+    # Replace `standAloneConfig` with the name of your configuration (your `username` or `"username@hostname"`)
     homeConfigurations.standAloneConfig = home-manager.lib.homeManagerConfiguration {
       pkgs = import nixpkgs { inherit system; };
 
@@ -45,7 +45,7 @@
       ];
     };
 
-    # Replace `moduleConfig` with the name of you configuration (your username or username@hostname)
+    # Replace `moduleConfig` with the name of you configuration (your `username` or `"username@hostname"`)
     nixosConfigurations.moduleConfig = nixpkgs.lib.nixosSystem {
       inherit system;
         modules = [

--- a/example/home.nix
+++ b/example/home.nix
@@ -1,5 +1,7 @@
 { pkgs, ... }:
 {
+  home.stateVersion = "23.11";
+
   programs.plasma = {
     enable = true;
 


### PR DESCRIPTION
I added a standalone home-manager example (it works) in addition to your home-manager-as-a-module example (which I couldn't make work).